### PR TITLE
No need to set DBNAME in hdfs_setup.sh

### DIFF
--- a/hdfs_setup.sh
+++ b/hdfs_setup.sh
@@ -2,7 +2,6 @@
 
 DSOURCES=('flow' 'dns')
 DFOLDERS=('binary' 'csv' 'hive' 'stage')
-DBNAME='duxbury'
 source /etc/duxbay.conf
 
 for d in "${DSOURCES[@]}" 


### PR DESCRIPTION
since it already gets configured in duxbay.conf
